### PR TITLE
Basic Workflow Polling

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ilnar/wf/gen/sqlc"
 	"github.com/ilnar/wf/internal/job"
+	"github.com/ilnar/wf/internal/schedule"
 	"github.com/ilnar/wf/internal/server"
 	"github.com/ilnar/wf/internal/storage"
 	"github.com/ilnar/wf/internal/workflow"
@@ -30,6 +31,9 @@ func main() {
 
 	wfs := workflow.New(logger, wfStore)
 	js := job.New(logger, jobStore)
+
+	sch := schedule.New(wfStore, logger)
+	go sch.Run(ctx)
 
 	port := 50051
 	srv := server.New(port, logger, wfs, js)

--- a/db/migration/000001_init_schema.up.sql
+++ b/db/migration/000001_init_schema.up.sql
@@ -3,5 +3,6 @@ CREATE TABLE "workflows" (
   "current_node" varchar NOT NULL,
   "status" varchar NOT NULL,
   "graph" jsonb NOT NULL,
-  "created_at" timestamptz NOT NULL DEFAULT (now())
+  "created_at" timestamptz NOT NULL DEFAULT (now()),
+  "next_action_at" timestamptz NOT NULL DEFAULT (now())
 );

--- a/db/query/workflow.sql
+++ b/db/query/workflow.sql
@@ -12,3 +12,9 @@ RETURNING *;
 -- name: GetWorkflow :one
 SELECT * FROM workflows
 WHERE id = $1 LIMIT 1;
+
+-- name: GetNextWorkflows :many
+SELECT * FROM workflows
+WHERE status = 'running'
+  AND next_action_at <= now()
+LIMIT 10;

--- a/gen/sqlc/models.go
+++ b/gen/sqlc/models.go
@@ -12,9 +12,10 @@ import (
 )
 
 type Workflow struct {
-	ID          uuid.UUID       `json:"id"`
-	CurrentNode string          `json:"current_node"`
-	Status      string          `json:"status"`
-	Graph       json.RawMessage `json:"graph"`
-	CreatedAt   time.Time       `json:"created_at"`
+	ID           uuid.UUID       `json:"id"`
+	CurrentNode  string          `json:"current_node"`
+	Status       string          `json:"status"`
+	Graph        json.RawMessage `json:"graph"`
+	CreatedAt    time.Time       `json:"created_at"`
+	NextActionAt time.Time       `json:"next_action_at"`
 }

--- a/internal/schedule/scheduler.go
+++ b/internal/schedule/scheduler.go
@@ -1,0 +1,91 @@
+package schedule
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	pb "github.com/ilnar/wf/gen/pb/api"
+	"github.com/ilnar/wf/internal/model"
+	"github.com/ilnar/wf/internal/storage"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const pollInterval = 30 * time.Second
+
+type Logger interface {
+	InfoContext(ctx context.Context, msg string, args ...any)
+	ErrorContext(ctx context.Context, msg string, args ...any)
+}
+
+type Scheduler struct {
+	wfStore   *storage.WorkflowStorage
+	jobClient pb.JobServiceClient
+	logger    Logger
+}
+
+func New(wfStore *storage.WorkflowStorage, l Logger) *Scheduler {
+	return &Scheduler{
+		wfStore: wfStore,
+		logger:  l,
+	}
+}
+
+func (s *Scheduler) Run(ctx context.Context) error {
+	s.logger.InfoContext(ctx, "Starting scheduler")
+
+	conn, err := grpc.DialContext(ctx, "localhost:50051",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to dial: %w", err)
+	}
+	defer conn.Close()
+
+	s.jobClient = pb.NewJobServiceClient(conn)
+
+	if err := s.poll(ctx); err != nil {
+		return fmt.Errorf("failed to poll: %w", err)
+	}
+	s.logger.InfoContext(ctx, "Stopping scheduler")
+	return nil
+}
+
+func (s *Scheduler) poll(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(pollInterval):
+			wfs, err := s.wfStore.GetNextWorkflows(ctx)
+			if err != nil {
+				s.logger.ErrorContext(ctx, "failed to list workflows", "err", err)
+				continue
+			}
+			for _, w := range wfs {
+				if err := s.schedule(ctx, w); err != nil {
+					s.logger.ErrorContext(ctx, "failed to schedule", "err", err)
+				}
+			}
+		}
+	}
+}
+
+func (s *Scheduler) schedule(ctx context.Context, w model.Workflow) error {
+	jcp := &pb.CreateRequest{
+		Id: w.ID.String(),
+		Reference: &pb.Reference{
+			WorkflowId:     uuid.NewString(),
+			WorkflowAction: w.CurrentNode,
+		},
+	}
+	s.logger.InfoContext(ctx, "Scheduling workflow", "request", jcp)
+	_, err := s.jobClient.Create(ctx, jcp)
+	if err != nil {
+		return fmt.Errorf("failed to create job: %w", err)
+	}
+	return nil
+}

--- a/internal/storage/workflow.go
+++ b/internal/storage/workflow.go
@@ -15,6 +15,7 @@ import (
 type DBQuery interface {
 	CreateWorkflow(ctx context.Context, arg sqlc.CreateWorkflowParams) (sqlc.Workflow, error)
 	GetWorkflow(ctx context.Context, id uuid.UUID) (sqlc.Workflow, error)
+	GetNextWorkflows(ctx context.Context) ([]sqlc.Workflow, error)
 }
 
 type WorkflowStorage struct {
@@ -25,7 +26,7 @@ func NewWorkflowStorage(q DBQuery) *WorkflowStorage {
 	return &WorkflowStorage{q: q}
 }
 
-func (s *WorkflowStorage) CreateWorkflow(ctx context.Context, w *model.Workflow) error {
+func (s *WorkflowStorage) CreateWorkflow(ctx context.Context, w model.Workflow) error {
 	gpb, err := w.Graph.ToProto()
 	if err != nil {
 		return fmt.Errorf("failed to convert graph to proto: %w", err)
@@ -46,20 +47,44 @@ func (s *WorkflowStorage) CreateWorkflow(ctx context.Context, w *model.Workflow)
 	return nil
 }
 
-func (s *WorkflowStorage) GetWorkflow(ctx context.Context, id uuid.UUID) (*model.Workflow, error) {
+func (s *WorkflowStorage) GetWorkflow(ctx context.Context, id uuid.UUID) (model.Workflow, error) {
 	w, err := s.q.GetWorkflow(ctx, id)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get workflow: %w", err)
+		return model.Workflow{}, fmt.Errorf("failed to get workflow: %w", err)
 	}
+	wm, err := workflowToModel(w)
+	if err != nil {
+		return model.Workflow{}, fmt.Errorf("failed to convert workflow: %w", err)
+	}
+	return wm, nil
+}
+
+func (s *WorkflowStorage) GetNextWorkflows(ctx context.Context) ([]model.Workflow, error) {
+	ws, err := s.q.GetNextWorkflows(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get next workflow: %w", err)
+	}
+	wms := make([]model.Workflow, 0, len(ws))
+	for _, w := range ws {
+		wm, err := workflowToModel(w)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert workflow: %w", err)
+		}
+		wms = append(wms, wm)
+	}
+	return wms, nil
+}
+
+func workflowToModel(w sqlc.Workflow) (model.Workflow, error) {
 	gpb := &pb.Graph{}
 	if err := protojson.Unmarshal(w.Graph, gpb); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal graph: %w", err)
+		return model.Workflow{}, fmt.Errorf("failed to unmarshal graph: %w", err)
 	}
 	g := &model.Graph{}
 	if err := g.FromProto(gpb); err != nil {
-		return nil, fmt.Errorf("failed to build graph: %w", err)
+		return model.Workflow{}, fmt.Errorf("failed to build graph: %w", err)
 	}
-	return &model.Workflow{
+	return model.Workflow{
 		ID:          w.ID,
 		CurrentNode: w.CurrentNode,
 		Status:      model.WorkflowStatus(w.Status),

--- a/internal/storage/workflow_test.go
+++ b/internal/storage/workflow_test.go
@@ -42,6 +42,10 @@ func (f *fakeDBQuery) GetWorkflow(_ context.Context, id uuid.UUID) (sqlc.Workflo
 	return w, nil
 }
 
+func (f *fakeDBQuery) GetNextWorkflows(_ context.Context) ([]sqlc.Workflow, error) {
+	return nil, nil
+}
+
 func TestCreateWorkflow(t *testing.T) {
 	txt := `
 		start: "a"
@@ -59,7 +63,7 @@ func TestCreateWorkflow(t *testing.T) {
 	id := uuid.MustParse("00000000-0000-0000-0000-000000000001")
 	ctx := context.Background()
 	ws := NewWorkflowStorage(newFakeDBQuery())
-	want := &model.Workflow{
+	want := model.Workflow{
 		ID:          id,
 		CurrentNode: "a",
 		Status:      model.WorkflowStatusPending,

--- a/internal/workflow/service.go
+++ b/internal/workflow/service.go
@@ -42,7 +42,7 @@ func (s *Server) Run(ctx context.Context, in *pb.RunRequest) (*pb.RunResponse, e
 	}
 	w := model.NewWorkflow(id, &g)
 	s.logger.InfoContext(ctx, "Running workflow", "w", w)
-	if err := s.store.CreateWorkflow(ctx, w); err != nil {
+	if err := s.store.CreateWorkflow(ctx, *w); err != nil {
 		return nil, fmt.Errorf("failed to create workflow: %w", err)
 	}
 	return &pb.RunResponse{}, nil


### PR DESCRIPTION
Create a scheduler that polls workflows that need execution. This is a very naive implementation.
The scheduler polls workflows and creates jobs using JobService gRPC client. The assumption is that scheduler will live with workflow API in the same binary and the job service will be a separate binary.